### PR TITLE
Update Vizard Rendering Rules and Improve `title`/`type` Handling

### DIFF
--- a/apps/md-renderer/src/main.ts
+++ b/apps/md-renderer/src/main.ts
@@ -25,14 +25,14 @@ window.addEventListener('DOMContentLoaded', () => {
         
         // Render chart based on chart type
         switch (chartType) {
-          case 'line':
-            renderLineChart(el, chartData)
+          case 'table':
+            renderTable(el, chartData)
             break
           case 'bar':
             renderBarChart(el, chartData)
             break
-          default:
-            renderTable(el, chartData)
+          case 'line':
+            renderLineChart(el, chartData)
             break
         }
       })

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -181,14 +181,14 @@ function renderMarkdownApp(root: HTMLElement) {
 					if (!encoded) return
 					const chartData = JSON.parse(decodeURIComponent(encoded))
 					switch (chartType) {
-						case 'line':
-							renderLineChart(el, chartData)
+						case 'table':
+							renderTable(el, chartData)
 							break
 						case 'bar':
 							renderBarChart(el, chartData)
 							break
-						default:
-							renderTable(el, chartData)
+						case 'line':
+							renderLineChart(el, chartData)
 							break
 					}
 				})

--- a/packages/src/markdown.ts
+++ b/packages/src/markdown.ts
@@ -1,6 +1,8 @@
 import MarkdownIt from 'markdown-it'
 import parseCSV from './parseCSV';
 
+const chartType: string[] = ["table", "bar", "line"]
+
 export function createMarkdownRenderer(): MarkdownIt {
   const md = new MarkdownIt()
   const defaultFence = md.renderer.rules.fence!
@@ -16,12 +18,14 @@ export function createMarkdownRenderer(): MarkdownIt {
       try {
         const parsed = parseCSV(token.content, info)
         console.log('Parsed CSV:', parsed);
-
-        // Render the original code block (for reference/debugging)
-        const codeHtml = `<pre><code class="language-csv">${md.utils.escapeHtml(token.content)}</code></pre>`
-
+        
         // Return both the original code block and a chart/table placeholder
-        return `${codeHtml}\n${generateChartHtml(parsed)}`
+        if (chartType.includes(parsed.type)) {
+          return `${generateChartHtml(parsed)}`
+        }
+        
+        // Render the original code block (for reference/debugging)
+        return `<pre><code class="language-csv">${md.utils.escapeHtml(token.content)}</code></pre>`
       } catch (e) {
         console.error('CSV parsing error:', e);
       }

--- a/packages/src/parseCSV.ts
+++ b/packages/src/parseCSV.ts
@@ -12,8 +12,8 @@ export default function parseCSV(
     info: string
 ): ParsedCSV {
     // Extract title and type from info string using regex
-    const titleMatch = info.match(/title="([^"]+)"/)
-    const typeMatch = info.match(/type="([^"]+)"/)
+    const titleMatch = info.match(/title\s*=\s*(?:"([^"]*)"|'([^']*)')/)
+    const typeMatch = info.match(/type\s*=\s*(?:"([^"]*)"|'([^']*)')/)
 
     const title = titleMatch ? titleMatch[1] : ''
     const type = typeMatch ? typeMatch[1] : ''


### PR DESCRIPTION
## ✨ Description of Changes

This PR updates the Vizard rendering behavior and improves the handling of `title` and `type` specifications.

* When no `type` is specified, Vizard will no longer render a table or any output.
* When a `type` is specified, only the rendering result is displayed; the original Markdown code block above the rendering is removed.
* Improved the way `title` and `type` can be specified in Markdown code blocks for better clarity and consistency.

---

## 🖼 Screenshots (if applicable)

<img width="882" height="542" alt="스크린샷 2025-08-21 오후 4 29 01" src="https://github.com/user-attachments/assets/2f36c03a-de14-4a3a-891f-1d87ed262c28" />

---

## 📎 Related Issues

Closes #26 

---

## ✅ Checklist

* [x] The new rendering behavior works as expected
* [x] `title` and `type` specifications are properly handled
* [x] Related issues are linked correctly
* [x] No unnecessary code or files are included